### PR TITLE
ci(rls): align nightly schedule to 02:30 UTC

### DIFF
--- a/.github/workflows/apply-rls.yml
+++ b/.github/workflows/apply-rls.yml
@@ -7,8 +7,8 @@ on:
     paths:
       - 'website-integration/ArrowheadSolution/drizzle/migrations/0001_blog_posts_rls.sql'
   schedule:
-    # Run nightly at 09:00 UTC (adjust in future if needed)
-    - cron: '0 9 * * *'
+    # Run nightly at 02:30 UTC to follow seed (02:00) and audit (02:17)
+    - cron: '30 2 * * *'
 
 concurrency:
   group: manage-rls-${{ github.ref }}


### PR DESCRIPTION
Aligns nightly RLS verification to 02:30 UTC to follow seed (02:00) and audit (02:17). Retains existing failure notification behavior which opens a GitHub Issue with run link and details. Closes #2.