### PR TITLE
feat(backend): Admin security baseline + GitHub auth health; CSRF endpoint

### DIFF
--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,0 +1,1 @@
+"""Backend package for server-side services (GitHub client, security, etc.)."""

--- a/backend/github_client.py
+++ b/backend/github_client.py
@@ -1,0 +1,35 @@
+import os
+import requests
+
+GITHUB_API = 'https://api.github.com'
+
+class GitHubClient:
+    """Minimal GitHub REST client using a server-side PAT.
+
+    Reads token from the environment variable `GITHUB_SERVER_TOKEN`.
+    Never expose this token to the client.
+    """
+
+    def __init__(self, token: str | None = None):
+        self.token = token or os.environ.get('GITHUB_SERVER_TOKEN')
+        if not self.token:
+            raise RuntimeError('Missing GITHUB_SERVER_TOKEN')
+        self.session = requests.Session()
+        self.session.headers.update({
+            'Authorization': f'Bearer {self.token}',
+            'Accept': 'application/vnd.github+json',
+            'X-GitHub-Api-Version': '2022-11-28',
+            'User-Agent': 'project-arrowhead-backend'
+        })
+
+    def get_user(self):
+        """Return authenticated user JSON and granted scopes header."""
+        resp = self.session.get(f'{GITHUB_API}/user', timeout=10)
+        resp.raise_for_status()
+        return resp.json(), resp.headers.get('X-OAuth-Scopes', '')
+
+    def get_repo(self, repo_full_name: str):
+        """Return repo JSON for owner/repo."""
+        resp = self.session.get(f'{GITHUB_API}/repos/{repo_full_name}', timeout=10)
+        resp.raise_for_status()
+        return resp.json()

--- a/backend/security.py
+++ b/backend/security.py
@@ -1,0 +1,35 @@
+import os
+import secrets
+from flask import request, session, abort
+
+ADMIN_HEADER = 'X-Admin-Key'
+CSRF_HEADER = 'X-CSRF-Token'
+
+
+def require_admin() -> None:
+    """Abort if the request does not present the correct admin key.
+    The expected key is read from ADMIN_API_KEY environment variable.
+    """
+    expected = os.environ.get('ADMIN_API_KEY')
+    if not expected:
+        abort(500, description='Server misconfigured: missing ADMIN_API_KEY')
+    provided = request.headers.get(ADMIN_HEADER)
+    if not provided or provided != expected:
+        abort(403, description='Forbidden: admin key missing or invalid')
+
+
+def issue_csrf() -> str:
+    """Create (or reuse) a CSRF token bound to the session and return it."""
+    token = session.get('csrf_token')
+    if not token:
+        token = secrets.token_urlsafe(32)
+        session['csrf_token'] = token
+    return token
+
+
+def verify_csrf() -> None:
+    """Abort if CSRF header does not match the session token."""
+    header = request.headers.get(CSRF_HEADER)
+    token = session.get('csrf_token')
+    if not token or not header or header != token:
+        abort(403, description='Forbidden: bad CSRF token')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,4 +9,5 @@ dependencies = [
     "flask-sqlalchemy>=3.1.1",
     "gunicorn>=23.0.0",
     "psycopg2-binary>=2.9.10",
+    "requests>=2.32.3",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ flask>=3.1.1
 flask-sqlalchemy>=3.1.1
 gunicorn>=23.0.0
 psycopg2-binary>=2.9.10
+requests>=2.32.3


### PR DESCRIPTION
Summary

Implements the backend foundation for the Control Panel (Issues #5 and #6):
- Server-side GitHub REST client using requests (env: GITHUB_SERVER_TOKEN)
- Admin security baseline: header-based admin key + CSRF issuance/verification
- Protected admin routes in Flask for CSRF issuance and GitHub token health check

Changes
- Add backend/github_client.py (GitHubClient with /user and repo helpers)
- Add backend/security.py (require_admin, issue_csrf, verify_csrf)
- Add backend/__init__.py
- Update app.py:
  - POST /api/admin/csrf (requires X-Admin-Key) => { csrfToken }
  - GET  /api/admin/health/github (requires X-Admin-Key + X-CSRF-Token)
- Dependencies: add requests to requirements.txt and pyproject.toml

Endpoints
- POST /api/admin/csrf
  - Headers: X-Admin-Key: <ADMIN_API_KEY>
  - Response: { "csrfToken": "..." }

- GET /api/admin/health/github
  - Headers: X-Admin-Key: <ADMIN_API_KEY>, X-CSRF-Token: <token from /api/admin/csrf>
  - Response: { ok: true, login, id, scopes } or { ok: false, error }

Required environment variables
- SESSION_SECRET (Flask session secret)
- ADMIN_API_KEY (server-only admin key; compared to X-Admin-Key header)
- GITHUB_SERVER_TOKEN (server-only PAT used by GitHubClient; never exposed)

Local testing
```bash
python -m pip install -r requirements.txt
export SESSION_SECRET=dev-secret
export ADMIN_API_KEY=dev-admin
export GITHUB_SERVER_TOKEN=ghp_... # PAT with basic user read; repo/read:org as needed
python app.py &

# 1) Issue CSRF token
curl -s -X POST http://localhost:5000/api/admin/csrf -H "X-Admin-Key: $ADMIN_API_KEY"
# => {"csrfToken":"..."}

# 2) Use the CSRF token for health check
CSRF_TOKEN="<paste token>"
curl -s http://localhost:5000/api/admin/health/github -H "X-Admin-Key: $ADMIN_API_KEY" -H "X-CSRF-Token: $CSRF_TOKEN"
```

Security notes
- Admin routes require a server-side header key and CSRF token bound to the Flask session.
- The GitHub PAT is only used on the server; it is never returned to clients.

Closes #5
Closes #6