### PR TITLE
CI: Run pytest on PRs to main

### DIFF
--- a/.github/workflows/python-pytest.yml
+++ b/.github/workflows/python-pytest.yml
@@ -1,0 +1,31 @@
+name: Python Tests
+
+on:
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  test:
+    name: Run pytest
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+          cache-dependency-path: requirements.txt
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run tests
+        run: |
+          pytest -q


### PR DESCRIPTION
Adds a GitHub Actions workflow to run pytest on all pull requests targeting main.

Details
- Triggers on pull_request to main and manual workflow_dispatch.
- Uses actions/setup-python@v5 with Python 3.11.
- Installs from requirements.txt and runs pytest -q.
- Caches pip based on requirements.txt.

This establishes an automated quality gate for backend changes.

Closes #12