### PR TITLE
feat(backend): Admin workflow control endpoints (Sprint 2)

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,12 +1,37 @@
 import os
-from flask import Flask, send_from_directory, request
+from flask import Flask, send_from_directory, request, jsonify
 from pathlib import Path
+from datetime import datetime, timezone, timedelta
+
+from backend.security import require_admin, issue_csrf, verify_csrf
+from backend.github_client import GitHubClient
 
 # Create the app
 app = Flask(__name__, static_folder='.', static_url_path='')
 
 # Configure the app
 app.secret_key = os.environ.get("SESSION_SECRET", "dev-secret-key-change-in-production")
+
+# --- Sprint 2: Control Panel (Workflows) ---
+# Hardcoded whitelist of admin workflows
+WORKFLOW_MAP = {
+    "verify-rls": "apply-rls.yml",
+    "seed": "seed-blog.yml",
+    "audit": "seed-audit.yml",
+}
+
+# Simple in-memory cache for status lookups
+WORKFLOW_STATUS_CACHE = {}
+WORKFLOW_STATUS_TTL_SECONDS = 20
+
+
+def _now_utc():
+    return datetime.now(timezone.utc)
+
+
+def get_github_client():
+    """Factory to create a GitHubClient. Patched in tests."""
+    return GitHubClient()
 
 @app.route('/')
 def index():
@@ -42,6 +67,97 @@ def serve_static(filename):
             response.headers['Expires'] = '0'
             return response
         return "File not found", 404
+
+
+# --- Admin: CSRF ---
+@app.route('/api/admin/csrf', methods=['POST'])
+def api_admin_csrf():
+    ok, err = require_admin(request)
+    if not ok:
+        return jsonify({"ok": False, "error": err}), 403
+    token = issue_csrf()
+    return jsonify({"ok": True, "csrfToken": token})
+
+
+# --- Admin: Workflows ---
+def _validate_workflow_name(name: str):
+    wf = WORKFLOW_MAP.get(name)
+    if not wf:
+        return None, jsonify({"ok": False, "error": "Unknown workflow name"}), 400
+    return wf, None, None
+
+
+@app.route('/api/admin/workflows/<name>/run', methods=['POST'])
+def api_admin_workflow_run(name):
+    ok, err = require_admin(request)
+    if not ok:
+        return jsonify({"ok": False, "error": err}), 403
+
+    ok_csrf, err_csrf = verify_csrf(request)
+    if not ok_csrf:
+        return jsonify({"ok": False, "error": err_csrf}), 403
+
+    workflow_file, resp, code = _validate_workflow_name(name)
+    if not workflow_file:
+        return resp, code
+
+    try:
+        client = get_github_client()
+        client.dispatch_workflow(workflow_file, ref="main")
+    except Exception as e:
+        return jsonify({"ok": False, "error": str(e)}), 500
+
+    # Invalidate cache so next status fetch refreshes
+    WORKFLOW_STATUS_CACHE.pop(name, None)
+
+    return (
+        jsonify({
+            "ok": True,
+            "name": name,
+            "ref": "main",
+            "dispatchedAt": _now_utc().isoformat(),
+        }),
+        202,
+    )
+
+
+@app.route('/api/admin/workflows/<name>/status', methods=['GET'])
+def api_admin_workflow_status(name):
+    ok, err = require_admin(request)
+    if not ok:
+        return jsonify({"ok": False, "error": err}), 403
+
+    workflow_file, resp, code = _validate_workflow_name(name)
+    if not workflow_file:
+        return resp, code
+
+    # Serve from cache if fresh
+    cache = WORKFLOW_STATUS_CACHE.get(name)
+    if cache:
+        fetched_at = cache.get("fetched_at")
+        if fetched_at and (_now_utc() - fetched_at) < timedelta(seconds=WORKFLOW_STATUS_TTL_SECONDS):
+            payload = dict(cache["data"])
+            payload["cached"] = True
+            return jsonify(payload)
+
+    try:
+        client = get_github_client()
+        latest = client.get_latest_run(workflow_file)
+    except Exception as e:
+        return jsonify({"ok": False, "error": str(e)}), 500
+
+    data = {
+        "ok": True,
+        "name": name,
+        "status": latest.get("status"),
+        "conclusion": latest.get("conclusion"),
+        "html_url": latest.get("html_url"),
+        "run_id": latest.get("id"),
+        "updated_at": latest.get("updated_at"),
+        "cached": False,
+    }
+    WORKFLOW_STATUS_CACHE[name] = {"data": data, "fetched_at": _now_utc()}
+    return jsonify(data)
 
 @app.errorhandler(404)
 def not_found(error):

--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,0 +1,1 @@
+"""Backend package for admin security and GitHub workflow integrations."""

--- a/backend/github_client.py
+++ b/backend/github_client.py
@@ -1,0 +1,87 @@
+import os
+from typing import Optional, Dict, Any
+
+import requests
+
+
+class GitHubClient:
+    """Minimal GitHub REST client for workflow dispatch and status queries.
+
+    Configuration precedence for owner/repo:
+    1) Explicit constructor args
+    2) GITHUB_OWNER + GITHUB_REPO
+    3) GITHUB_REPOSITORY ("owner/repo")
+    """
+
+    def __init__(
+        self,
+        token: Optional[str] = None,
+        owner: Optional[str] = None,
+        repo: Optional[str] = None,
+        session: Optional[requests.Session] = None,
+    ) -> None:
+        self._token = token or os.environ.get("GITHUB_SERVER_TOKEN")
+        if not self._token:
+            raise RuntimeError("GITHUB_SERVER_TOKEN is not set")
+
+        if owner and repo:
+            self.owner, self.repo = owner, repo
+        else:
+            env_owner, env_repo = os.environ.get("GITHUB_OWNER"), os.environ.get("GITHUB_REPO")
+            if env_owner and env_repo:
+                self.owner, self.repo = env_owner, env_repo
+            else:
+                full = os.environ.get("GITHUB_REPOSITORY")
+                if full and "/" in full:
+                    self.owner, self.repo = full.split("/", 1)
+                else:
+                    raise RuntimeError(
+                        "GitHub repo not configured: set GITHUB_OWNER + GITHUB_REPO or GITHUB_REPOSITORY"
+                    )
+
+        self.base_url = "https://api.github.com"
+        self.timeout = float(os.environ.get("GITHUB_HTTP_TIMEOUT", "10"))
+        self.session = session or requests.Session()
+        self.session.headers.update(
+            {
+                "Authorization": f"Bearer {self._token}",
+                "Accept": "application/vnd.github+json",
+                "User-Agent": "project-arrowhead-control/1.0",
+            }
+        )
+
+    def dispatch_workflow(self, workflow_file: str, ref: str = "main") -> None:
+        """Trigger a workflow_dispatch on the given workflow file.
+
+        GitHub returns 204 No Content on success.
+        """
+        url = f"{self.base_url}/repos/{self.owner}/{self.repo}/actions/workflows/{workflow_file}/dispatches"
+        resp = self.session.post(url, json={"ref": ref}, timeout=self.timeout)
+        # Accept any 2xx (GitHub typically returns 204)
+        if resp.status_code // 100 != 2:
+            resp.raise_for_status()
+
+    def get_latest_run(self, workflow_file: str) -> Dict[str, Any]:
+        """Return a simplified dict for the latest run of the workflow."""
+        url = f"{self.base_url}/repos/{self.owner}/{self.repo}/actions/workflows/{workflow_file}/runs"
+        params = {"per_page": 1}
+        resp = self.session.get(url, params=params, timeout=self.timeout)
+        resp.raise_for_status()
+        data = resp.json()
+        runs = data.get("workflow_runs") or data.get("runs") or []
+        if not runs:
+            return {
+                "status": "unknown",
+                "conclusion": None,
+                "html_url": None,
+                "id": None,
+                "updated_at": None,
+            }
+        run = runs[0]
+        return {
+            "status": run.get("status"),
+            "conclusion": run.get("conclusion"),
+            "html_url": run.get("html_url"),
+            "id": run.get("id") or run.get("run_id"),
+            "updated_at": run.get("updated_at") or run.get("created_at"),
+        }

--- a/backend/security.py
+++ b/backend/security.py
@@ -1,0 +1,51 @@
+import os
+import secrets
+from typing import Tuple, Optional
+from flask import Request, session
+
+# Environment: ADMIN_API_KEY must be set in the server environment
+
+
+def require_admin(request: Request) -> Tuple[bool, Optional[str]]:
+    """Validate the admin key present in X-Admin-Key header.
+
+    Returns (ok, error).
+    """
+    admin_api_key = os.environ.get("ADMIN_API_KEY")
+    if not admin_api_key:
+        return False, "Server misconfigured: ADMIN_API_KEY is not set"
+
+    header_key = request.headers.get("X-Admin-Key")
+    if not header_key:
+        return False, "Missing X-Admin-Key"
+
+    if header_key != admin_api_key:
+        return False, "Invalid admin key"
+
+    return True, None
+
+
+def issue_csrf() -> str:
+    """Create a CSRF token and store it in the Flask session."""
+    token = secrets.token_urlsafe(32)
+    session["csrf_token"] = token
+    return token
+
+
+def verify_csrf(request: Request) -> Tuple[bool, Optional[str]]:
+    """Verify the X-CSRF-Token header matches the token in session.
+
+    Returns (ok, error).
+    """
+    expected = session.get("csrf_token")
+    if not expected:
+        return False, "Missing CSRF token in session"
+
+    got = request.headers.get("X-CSRF-Token")
+    if not got:
+        return False, "Missing X-CSRF-Token"
+
+    if got != expected:
+        return False, "Invalid CSRF token"
+
+    return True, None

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ flask>=3.1.1
 flask-sqlalchemy>=3.1.1
 gunicorn>=23.0.0
 psycopg2-binary>=2.9.10
+requests>=2.32.0
+pytest>=8.2.0

--- a/tests/test_admin_workflows.py
+++ b/tests/test_admin_workflows.py
@@ -1,0 +1,123 @@
+import os
+import types
+import time
+import sys
+from pathlib import Path
+
+import pytest
+
+
+class FakeGitHubClient:
+    def __init__(self):
+        self.dispatched = []
+        self.status_calls = 0
+        self.latest = {
+            "status": "completed",
+            "conclusion": "success",
+            "html_url": "https://github.com/example/run/1",
+            "id": 1,
+            "updated_at": "2025-01-01T00:00:00Z",
+        }
+
+    def dispatch_workflow(self, workflow_file: str, ref: str = "main"):
+        self.dispatched.append((workflow_file, ref))
+
+    def get_latest_run(self, workflow_file: str):
+        self.status_calls += 1
+        return dict(self.latest)
+
+
+@pytest.fixture(autouse=True)
+def set_env(monkeypatch):
+    monkeypatch.setenv("ADMIN_API_KEY", "test-admin")
+    # Avoid accidental use of real network by ensuring server token is absent in tests
+    monkeypatch.delenv("GITHUB_SERVER_TOKEN", raising=False)
+    yield
+
+
+@pytest.fixture()
+def app_client(monkeypatch):
+    # Import app and patch get_github_client to return our singleton fake
+    import importlib
+    # Ensure project root is on sys.path for `import app`
+    project_root = str(Path(__file__).resolve().parent.parent)
+    if project_root not in sys.path:
+        sys.path.insert(0, project_root)
+    app_module = importlib.import_module("app")
+
+    fake = FakeGitHubClient()
+    monkeypatch.setattr(app_module, "get_github_client", lambda: fake)
+
+    client = app_module.app.test_client()
+    return types.SimpleNamespace(client=client, app_module=app_module, fake=fake)
+
+
+def test_csrf_and_dispatch_seed(app_client):
+    c = app_client.client
+
+    # Issue CSRF
+    resp = c.post("/api/admin/csrf", headers={"X-Admin-Key": "test-admin"})
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["ok"] is True
+    csrf = data["csrfToken"]
+
+    # Dispatch seed (main default)
+    resp = c.post(
+        "/api/admin/workflows/seed/run",
+        headers={
+            "X-Admin-Key": "test-admin",
+            "X-CSRF-Token": csrf,
+            "Content-Type": "application/json",
+        },
+        json={},
+    )
+    assert resp.status_code == 202
+    body = resp.get_json()
+    assert body["ok"] is True
+    assert body["name"] == "seed"
+    assert body["ref"] == "main"
+
+    # Verify fake recorded dispatch
+    assert app_client.fake.dispatched == [("seed-blog.yml", "main")]
+
+
+def test_status_caching_within_ttl(app_client, monkeypatch):
+    c = app_client.client
+
+    # First call should fetch from fake
+    resp1 = c.get("/api/admin/workflows/audit/status", headers={"X-Admin-Key": "test-admin"})
+    assert resp1.status_code == 200
+    body1 = resp1.get_json()
+    assert body1["ok"] is True
+    assert body1["name"] == "audit"
+    assert body1["cached"] is False
+
+    # Second call within TTL should be served from cache
+    resp2 = c.get("/api/admin/workflows/audit/status", headers={"X-Admin-Key": "test-admin"})
+    assert resp2.status_code == 200
+    body2 = resp2.get_json()
+    assert body2["cached"] is True
+
+    # Only one status fetch should have happened
+    assert app_client.fake.status_calls == 1
+
+
+def test_unknown_workflow_returns_400(app_client):
+    c = app_client.client
+    resp = c.get("/api/admin/workflows/unknown/status", headers={"X-Admin-Key": "test-admin"})
+    assert resp.status_code == 400
+    body = resp.get_json()
+    assert body["ok"] is False
+    assert "Unknown workflow" in body["error"]
+
+
+def test_requires_admin_headers(app_client):
+    c = app_client.client
+    # Missing admin key on CSRF
+    resp = c.post("/api/admin/csrf")
+    assert resp.status_code == 403
+
+    # Missing admin key on status
+    resp = c.get("/api/admin/workflows/seed/status")
+    assert resp.status_code == 403


### PR DESCRIPTION
This PR implements the Sprint 2 backend workflow control endpoints.\n\nSummary\n- Add backend/security.py (admin + CSRF helpers)\n- Add backend/github_client.py (workflow dispatch + latest run status)\n- Update app.py with /api/admin endpoints and 20s status cache\n- Add tests/test_admin_workflows.py (4 passing)\n- Update requirements.txt (requests, pytest)\n\nRuntime/Env\n- SESSION_SECRET, ADMIN_API_KEY, GITHUB_SERVER_TOKEN must be set\n- Repo config via GITHUB_REPOSITORY (or GITHUB_OWNER + GITHUB_REPO)\n\nRefs #16