### PR TITLE
ui(ops): Data Health badges + Force Refresh

### DIFF
--- a/website-integration/ArrowheadSolution/client/src/services/adminApi.ts
+++ b/website-integration/ArrowheadSolution/client/src/services/adminApi.ts
@@ -7,11 +7,11 @@ export const API_BASE = (
   import.meta as ImportMeta & { env?: { VITE_ADMIN_API_BASE?: string } }
 ).env?.VITE_ADMIN_API_BASE ?? "/pyapi";
 
-export async function getDataHealth(adminKey: string): Promise<DataHealth> {
+export async function getDataHealth(adminKey: string, opts?: { noCache?: boolean }): Promise<DataHealth> {
   if (!adminKey) {
     throw new AdminApiError(403, "Missing admin key");
   }
-  const url = `${API_BASE}/admin/data-health`;
+  const url = `${API_BASE}/admin/data-health${opts?.noCache ? "?noCache=1" : ""}`;
   const res = await fetch(url, {
     method: "GET",
     headers: {

--- a/website-integration/ArrowheadSolution/client/src/types/admin.ts
+++ b/website-integration/ArrowheadSolution/client/src/types/admin.ts
@@ -14,6 +14,7 @@ export type DataHealth = {
     expires_at?: string | null;
   } | null;
   cached?: boolean;
+  stale?: boolean;
   fetched_at?: string;
   cache_ttl_seconds?: number;
 };


### PR DESCRIPTION
This PR enhances the Data Health admin UI:\n- Displays Cached/Stale badges\n- Adds Force Refresh button that uses ?noCache=1 via adminApi\n- Updates types and service layer accordingly\n\nTracking: https://github.com/blaine-w-gates/project-arrowhead/issues/27