### PR TITLE
final(polish): runbook link + Stale E2E + Sprint 3 complete

### DIFF
--- a/Sprint_Plan_v4.1.md
+++ b/Sprint_Plan_v4.1.md
@@ -119,6 +119,7 @@ E2E happy path green.
 
 
 Sprint 3 — Control Panel v2: Data Health & QA (4–6 days)
+Status: Completed on 2025-09-10. Delivered: Backend Data Health API (noCache/TTL/stale fallback), React UI DataHealthCard with badges and Force Refresh, E2E coverage incl. stale badge, and incident runbook; CI pytest workflow stabilized.
 GET /api/admin/data-health (latest seed-audit.json artifact)
 
 

--- a/website-integration/ArrowheadSolution/client/src/components/admin/DataHealthCard.tsx
+++ b/website-integration/ArrowheadSolution/client/src/components/admin/DataHealthCard.tsx
@@ -100,6 +100,17 @@ export default function DataHealthCard({ adminKey }: Props) {
                 View run in GitHub
               </a>
             )}
+
+            <div>
+              <a
+                href="https://github.com/blaine-w-gates/project-arrowhead/blob/main/docs/data-health-runbook.md"
+                target="_blank"
+                rel="noreferrer"
+                className="text-xs text-muted-foreground underline"
+              >
+                Incident runbook
+              </a>
+            </div>
           </div>
         )}
       </CardContent>

--- a/website-integration/ArrowheadSolution/tests/e2e/data-health-stale.spec.ts
+++ b/website-integration/ArrowheadSolution/tests/e2e/data-health-stale.spec.ts
@@ -1,0 +1,40 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Verifies that the Data Health card renders the "Stale" badge
+ * when the backend returns a stale cached payload.
+ */
+test('Data Health shows Stale badge when backend serves stale cache', async ({ page }) => {
+  // Intercept the admin data-health endpoint to return a canned stale response
+  await page.route('**/pyapi/admin/data-health*', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        ok: true,
+        drift_ok: true,
+        counts: { fs: 10, db: 10 },
+        drift: { only_fs: [], only_db: [] },
+        cached: true,
+        stale: true,
+        fetched_at: new Date().toISOString(),
+        cache_ttl_seconds: 60,
+        run: { id: 123, url: 'https://github.com/blaine-w-gates/project-arrowhead/actions/runs/123' },
+      }),
+    });
+  });
+
+  // Ensure Admin Key is present so the hook is enabled
+  await page.addInitScript(() => {
+    localStorage.setItem('adminKey', 'test-admin');
+  });
+
+  // Navigate to the Ops admin page
+  await page.goto('/ops');
+
+  // Expect the Stale badge to be visible
+  await expect(page.getByText('Stale')).toBeVisible();
+
+  // Quick sanity: incident runbook link is present
+  await expect(page.getByRole('link', { name: 'Incident runbook' })).toBeVisible();
+});


### PR DESCRIPTION
This PR bundles the final polish for the Control Panel & Data Governance epic.\n\n- UI: Add link to the incident runbook in DataHealthCard (ops).\n- E2E: New Playwright spec validating the Stale badge when backend serves cached stale payload.\n- Docs: Update Sprint_Plan_v4.1.md to mark Sprint 3 as complete and summarize deliverables.\n\nAll changes are additive and low risk. Please review and squash-merge.