### PR TITLE
feat(api): ConvertKit integration behind feature flag

### DIFF
--- a/website-integration/ArrowheadSolution/functions/api/lead-magnet.ts
+++ b/website-integration/ArrowheadSolution/functions/api/lead-magnet.ts
@@ -264,7 +264,8 @@ export const onRequestPost = async ({ request, env }: { request: Request; env: R
               const kind = (err as Error)?.name === 'AbortError' ? 'timeout' : 'error';
               console.log(JSON.stringify({ evt: "ck_debug", stage: kind, message: (err as Error)?.message || String(err), timeout_ms: timeoutMs }));
             } finally {
-              try { clearTimeout(to); } catch {}
+              // Always clear the timeout; clearTimeout does not throw
+              clearTimeout(to);
             }
           }
         } else {


### PR DESCRIPTION
Implements ConvertKit Forms subscribe in `functions/api/lead-magnet.ts` when `CONVERTKIT_ENABLED=true`.\n\n- Uses `CONVERTKIT_API_SECRET`, `CONVERTKIT_FORM_ID`, `CONVERTKIT_BASE_URL` (default v3), `CONVERTKIT_DOUBLE_OPT_IN`, `CONVERTKIT_TIMEOUT_MS`.\n- Adds structured `ck_debug` logs for response/timeout/error.\n- Preserves user success semantics on ESP failure; Supabase insert remains source of truth.\n- Leaves CORS improvements from prior hotfixes intact.