### PR TITLE
fix(api): Correct ConvertKit subscribe payload (api_key/api_secret)

### DIFF
--- a/website-integration/ArrowheadSolution/functions/api/lead-magnet.ts
+++ b/website-integration/ArrowheadSolution/functions/api/lead-magnet.ts
@@ -241,7 +241,6 @@ export const onRequestPost = async ({ request, env }: { request: Request; env: R
           const formId = (env.CONVERTKIT_FORM_ID || "").trim();
           const apiKey = (env.CONVERTKIT_API_KEY || "").trim();
           const apiSecret = (env.CONVERTKIT_API_SECRET || "").trim();
-          const doubleOptIn = (env.CONVERTKIT_DOUBLE_OPT_IN || "false").toLowerCase() === "true";
           const timeoutMsRaw = parseInt(String(env.CONVERTKIT_TIMEOUT_MS || 4000), 10);
           const timeoutMs = Number.isFinite(timeoutMsRaw) ? Math.max(1000, Math.min(timeoutMsRaw, 15000)) : 4000;
 


### PR DESCRIPTION
Hotfix for ConvertKit integration in `functions/api/lead-magnet.ts`.\n\n- Send `api_key` if provided, otherwise `api_secret`.\n- Remove `double_opt_in` from subscribe payload (managed in ConvertKit).\n- Enhanced `ck_debug` with which credential was used.\n\nRationale: ConvertKit `/forms/:id/subscribe` expects `email` plus either `api_key` or `api_secret`. Including unsupported fields or wrong credential field can result in silent ESP failure while the function still returns 200 by design.\n\nPlease review, merge, and redeploy preview to validate with real test email.