### PR TITLE
feat(blog): Post Template — single-column layout, ToC, SEO meta, prev/next

### DIFF
--- a/website-integration/ArrowheadSolution/client/src/components/blog/TableOfContents.tsx
+++ b/website-integration/ArrowheadSolution/client/src/components/blog/TableOfContents.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+
+export interface TocHeading {
+  id: string;
+  text: string;
+  depth: 2 | 3;
+}
+
+interface TableOfContentsProps {
+  headings: TocHeading[];
+}
+
+export default function TableOfContents({ headings }: TableOfContentsProps) {
+  if (!headings || headings.length === 0) return null;
+
+  return (
+    <div className="mb-8 rounded-lg border bg-card text-card-foreground shadow">
+      <div className="p-6">
+        <h3 className="text-sm font-semibold text-muted-foreground uppercase tracking-wide mb-3">
+          Table of Contents
+        </h3>
+        <nav aria-label="Table of contents">
+          <ul className="space-y-2">
+            {headings.map((h) => (
+              <li key={h.id} className={h.depth === 3 ? "pl-4 border-l" : undefined}>
+                <a
+                  href={`#${h.id}`}
+                  className="text-sm text-foreground hover:text-primary"
+                >
+                  {h.text}
+                </a>
+              </li>
+            ))}
+          </ul>
+        </nav>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Implements Blog Post Template per Sprint v6.0:\n- Clean single-column typography\n- Auto Table of Contents (h2/h3) with stable anchor IDs\n- SEO meta via react-helmet-async (title, canonical, OpenGraph, Twitter)\n- Previous/Next navigation based on published order\n\nUses existing markdown content as placeholder. Includes only template structure; content work will follow in a separate PR.