### PR TITLE
Fix: Add missing sync-cloudflare-config.mjs script

### DIFF
--- a/website-integration/ArrowheadSolution/package.json
+++ b/website-integration/ArrowheadSolution/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "node scripts/sync-admin-config.mjs && NODE_ENV=development tsx server/index.ts",
     "dev:client": "vite",
-    "prebuild": "node scripts/sync-admin-config.mjs && node scripts/generate-seo.mjs",
+    "prebuild": "node scripts/sync-cloudflare-config.mjs && node scripts/sync-admin-config.mjs && node scripts/generate-seo.mjs",
     "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
     "postbuild": "node scripts/check-build-admin.mjs",
     "start": "NODE_ENV=production node dist/index.js",

--- a/website-integration/ArrowheadSolution/scripts/sync-cloudflare-config.mjs
+++ b/website-integration/ArrowheadSolution/scripts/sync-cloudflare-config.mjs
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+/**
+ * Sync Cloudflare Pages config files (_redirects, _headers) to client/public
+ * so Vite includes them in the build output.
+ */
+import fs from 'fs/promises';
+import path from 'path';
+
+async function main() {
+  const root = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..');
+  const source = path.join(root, 'public');
+  const dest = path.join(root, 'client', 'public');
+
+  const files = ['_redirects', '_headers'];
+
+  for (const file of files) {
+    const src = path.join(source, file);
+    const dst = path.join(dest, file);
+    try {
+      await fs.copyFile(src, dst);
+      console.log(`[sync-cloudflare-config] Copied ${file} to client/public/`);
+    } catch (err) {
+      console.error(`[sync-cloudflare-config] Failed to copy ${file}:`, err);
+      process.exit(1);
+    }
+  }
+}
+
+main().catch((e) => {
+  console.error('[sync-cloudflare-config] Error:', e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Root Cause

The sync script was created in a local branch but never made it to main. This caused:
- `prebuild` didn't sync config files from `public/` to `client/public/`
- Vite built with the wrong `_redirects` file
- Cloudflare rejected wildcard rules, causing 404s

## Changes

1. **Created `scripts/sync-cloudflare-config.mjs`** - Copies `_redirects` and `_headers` to client/public
2. **Updated `prebuild` in package.json** - Runs sync script before build
3. **Fixed `public/_redirects`** - Removed wildcard rules (not supported by Cloudflare)

## Expected Result

Deployment log should show:
```
[sync-cloudflare-config] Copied _redirects to client/public/
[sync-cloudflare-config] Copied _headers to client/public/
Parsed 2 valid redirect rules.
✨ Success!
```

Then `/admin-lite` should load correctly on production.