### PR TITLE
Fix: Copy admin-lite to client/public for build inclusion

### DIFF
--- a/website-integration/ArrowheadSolution/client/public/admin-lite/index.html
+++ b/website-integration/ArrowheadSolution/client/public/admin-lite/index.html
@@ -1,0 +1,91 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Decap CMS Admin (Lite)</title>
+  <meta name="robots" content="noindex,nofollow,noarchive" />
+  <script>
+    // Minimal, isolated sandbox: no custom reloads; just init + diagnostics.
+    window.CMS_MANUAL_INIT = true;
+    window.__ADMIN_LITE__ = { logs: [], gotMessage: false, tokenPersisted: false };
+
+    // Inline config with oauth-lite endpoints
+    window.CMS_CONFIG = {
+      backend: {
+        name: 'github',
+        repo: 'blaine-w-gates/project-arrowhead',
+        branch: 'main',
+        base_url: '/api/oauth-lite',
+        auth_endpoint: 'auth'
+      },
+      media_folder: 'website-integration/ArrowheadSolution/public/images/uploads',
+      public_folder: '/images/uploads',
+      collections: [
+        {
+          name: 'blog',
+          label: 'Blog',
+          folder: 'website-integration/ArrowheadSolution/content/blog',
+          create: true,
+          slug: '{{year}}-{{month}}-{{day}}-{{slug}}',
+          fields: [
+            { label: 'Title', name: 'title', widget: 'string' },
+            { label: 'Body', name: 'body', widget: 'markdown' }
+          ]
+        }
+      ]
+    };
+  </script>
+</head>
+<body>
+  <h1 style="position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden;">Decap CMS Admin (Lite)</h1>
+  <div id="status" style="position:fixed;bottom:8px;left:8px;background:#000;color:#0f0;padding:6px 8px;font:12px/1.3 monospace;opacity:.85;z-index:9999"></div>
+  <script src="https://unpkg.com/decap-cms@3.0.0/dist/decap-cms.js"></script>
+  <script>
+    (function(){
+      function log(msg){ try { window.__ADMIN_LITE__.logs.push(msg); document.getElementById('status').textContent = msg; } catch(e){} }
+      function init(){
+        if (window.CMS && typeof CMS.init === 'function'){
+          log('CMS.init start');
+          CMS.init({ config: window.CMS_CONFIG, load_config_file: false });
+          log('CMS.init done');
+        } else {
+          setTimeout(init, 60);
+        }
+      }
+      // Listen for both Decap success formats; persist token but do not reload.
+      if (!window.__LITE_MSG__){
+        window.__LITE_MSG__ = true;
+        window.addEventListener('message', function(ev){
+          try {
+            var d = ev && ev.data; if (typeof d !== 'string') return;
+            if (d === 'authorization:github:success' || d.indexOf('authorization:github:success:') === 0){
+              window.__ADMIN_LITE__.gotMessage = true; log('received success msg');
+              var tok = null;
+              if (d.indexOf(':') > -1){
+                try { var s = d.replace('authorization:github:success:', ''); var p = JSON.parse(s||'{}'); tok = p.token || null; } catch(e){}
+              }
+              if (!tok){
+                var keys = ['decap-cms.user','netlify-cms.user','decap-cms:user','netlify-cms-user','decap-cms-auth'];
+                for (var i=0;i<keys.length;i++){ try { var raw = localStorage.getItem(keys[i]); if (!raw) continue; var o = JSON.parse(raw); if (o && o.token){ tok = o.token; break; } } catch(e){} }
+              }
+              if (tok){
+                try { localStorage.setItem('netlify-cms.user', JSON.stringify({ token: tok })); } catch(e){}
+                try { localStorage.setItem('decap-cms.user', JSON.stringify({ token: tok })); } catch(e){}
+                try { localStorage.setItem('netlify-cms-user', JSON.stringify({ token: tok })); } catch(e){}
+                try { localStorage.setItem('decap-cms:user', JSON.stringify({ token: tok })); } catch(e){}
+                try { localStorage.setItem('decap-cms-auth', JSON.stringify({ token: tok, provider: 'github' })); } catch(e){}
+                window.__ADMIN_LITE__.tokenPersisted = true; log('token persisted');
+                try { location.hash = '#/collections/blog'; } catch(e){}
+              } else {
+                log('no token in message or storage');
+              }
+            }
+          } catch(e){}
+        });
+      }
+      init();
+    })();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Root Cause

The `/admin-lite` directory only existed in `public/` but Vite builds from `client/`.

The _redirects file had rules for `/admin-lite` and Cloudflare was parsing them correctly, but the actual HTML files weren't in the build output (`dist/public/`).

This is why:
- Build logs showed "Parsed 2 valid redirect rules" ✓
- But `/admin-lite` still 404'd ✗

## Fix

Copied `public/admin-lite/` to `client/public/admin-lite/` so Vite includes it in the build.

## Testing

After merge, `/admin-lite` should finally load on production.