### PR TITLE
Fix: Add guarded reload to complete CMS authentication flow

### DIFF
--- a/website-integration/ArrowheadSolution/client/public/admin-lite/index.html
+++ b/website-integration/ArrowheadSolution/client/public/admin-lite/index.html
@@ -76,6 +76,16 @@
                 try { localStorage.setItem('decap-cms:user', JSON.stringify({ token: tok })); } catch(e){}
                 try { localStorage.setItem('decap-cms-auth', JSON.stringify({ token: tok, provider: 'github' })); } catch(e){}
                 window.__ADMIN_LITE__.tokenPersisted = true; log('token persisted');
+                // Guarded reload: Decap CMS needs a page refresh to read token from localStorage
+                var guard = '__ADMIN_AUTH_RELOADED_PERSIST__';
+                try {
+                  if (!localStorage.getItem(guard)){
+                    localStorage.setItem(guard, Date.now().toString());
+                    log('reloading once');
+                    setTimeout(function(){ location.reload(); }, 150);
+                    return;
+                  }
+                } catch(e){}
                 try { location.hash = '#/collections/blog'; } catch(e){}
               } else {
                 log('no token in message or storage');

--- a/website-integration/ArrowheadSolution/public/admin-lite/index.html
+++ b/website-integration/ArrowheadSolution/public/admin-lite/index.html
@@ -76,6 +76,16 @@
                 try { localStorage.setItem('decap-cms:user', JSON.stringify({ token: tok })); } catch(e){}
                 try { localStorage.setItem('decap-cms-auth', JSON.stringify({ token: tok, provider: 'github' })); } catch(e){}
                 window.__ADMIN_LITE__.tokenPersisted = true; log('token persisted');
+                // Guarded reload: Decap CMS needs a page refresh to read token from localStorage
+                var guard = '__ADMIN_AUTH_RELOADED_PERSIST__';
+                try {
+                  if (!localStorage.getItem(guard)){
+                    localStorage.setItem(guard, Date.now().toString());
+                    log('reloading once');
+                    setTimeout(function(){ location.reload(); }, 150);
+                    return;
+                  }
+                } catch(e){}
                 try { location.hash = '#/collections/blog'; } catch(e){}
               } else {
                 log('no token in message or storage');


### PR DESCRIPTION
## Root Cause

Decap CMS doesn't automatically re-initialize after the OAuth callback saves the token to localStorage. The library requires a page refresh to read the token and render the authenticated UI.

## Evidence

Screenshot shows:
- ✅ Token saved to localStorage ("token persisted")
- ✅ URL changed to `#/collections/blog`
- ❌ Still showing login screen (CMS not re-initialized)

## Solution: Guarded Single Reload

Added guard flag `__ADMIN_AUTH_RELOADED_PERSIST__` in localStorage:

1. After saving token, check if guard exists
2. If not, set guard and `location.reload()` once
3. On reload, guard prevents further reloads
4. CMS initializes with token and shows collections

This ensures:
- ✅ CMS properly reads token
- ✅ No infinite reload loops
- ✅ Clean authenticated state

## Testing

After merge:
1. Clear localStorage for `project-arrowhead.pages.dev`
2. Navigate to `/admin-lite`
3. Click "Login with GitHub"
4. Authorize in popup
5. Should see: "reloading once" message, then CMS collections view