### PR TITLE
Fix: Add unpkg.com to CSP connect-src (THE ACTUAL ROOT CAUSE)

### DIFF
--- a/website-integration/ArrowheadSolution/public/_headers
+++ b/website-integration/ArrowheadSolution/public/_headers
@@ -16,4 +16,4 @@
   X-Robots-Tag: noindex, nofollow, noarchive
   Cache-Control: no-store
   X-Frame-Options: SAMEORIGIN
-  Content-Security-Policy: default-src 'self' https://unpkg.com; base-uri 'self'; frame-ancestors 'self'; object-src 'none'; form-action 'self' https://github.com; connect-src 'self' https://api.github.com; img-src 'self' data: blob:; style-src 'self' 'unsafe-inline'; font-src 'self' data:; script-src 'self' 'unsafe-inline' https://unpkg.com; frame-src 'self' https://github.com; upgrade-insecure-requests; block-all-mixed-content
+  Content-Security-Policy: default-src 'self' https://unpkg.com; base-uri 'self'; frame-ancestors 'self'; object-src 'none'; form-action 'self' https://github.com; connect-src 'self' https://api.github.com https://unpkg.com; img-src 'self' data: blob:; style-src 'self' 'unsafe-inline'; font-src 'self' data:; script-src 'self' 'unsafe-inline' https://unpkg.com; frame-src 'self' https://github.com; upgrade-insecure-requests; block-all-mixed-content


### PR DESCRIPTION
## The Real Root Cause

Console error from screenshot:
```
Refused to connect to 'https://unpkg.com/decap-cms@3.0.0/dist/...'
because it violates the following Content Security Policy directive:
"connect-src 'self' https://api.github.com"
```

**Decap CMS cannot load because CSP blocks unpkg.com connections.**

## Why This Caused the Stuck Login

1. ✅ OAuth works - token saved successfully
2. ✅ Page reloads (with or without guard)
3. ❌ **Decap CMS tries to load modules from unpkg.com**
4. ❌ **CSP blocks the connection**
5. ❌ CMS fails to initialize, stays on login screen

## The Fix

Added `https://unpkg.com` to `connect-src` directive:

```
connect-src 'self' https://api.github.com https://unpkg.com;
```

## Testing

After deployment:
1. Clear localStorage
2. Login via GitHub
3. **CMS should now fully load and show collections** ✅