### PR TITLE
Fix: Auto-clear stale reload guards to prevent stuck auth

### DIFF
--- a/website-integration/ArrowheadSolution/client/public/admin-lite/index.html
+++ b/website-integration/ArrowheadSolution/client/public/admin-lite/index.html
@@ -47,6 +47,18 @@
       function init(){
         if (window.CMS && typeof CMS.init === 'function'){
           log('CMS.init start');
+          // Clear any stale reload guard older than 2 minutes on init
+          try {
+            var guard = '__ADMIN_AUTH_RELOADED_PERSIST__';
+            var guardVal = localStorage.getItem(guard);
+            if (guardVal) {
+              var age = Date.now() - parseInt(guardVal || '0', 10);
+              if (age > 120000) { // 2 minutes
+                localStorage.removeItem(guard);
+                log('cleared stale guard');
+              }
+            }
+          } catch(e){}
           CMS.init({ config: window.CMS_CONFIG, load_config_file: false });
           log('CMS.init done');
         } else {

--- a/website-integration/ArrowheadSolution/public/admin-lite/index.html
+++ b/website-integration/ArrowheadSolution/public/admin-lite/index.html
@@ -47,6 +47,18 @@
       function init(){
         if (window.CMS && typeof CMS.init === 'function'){
           log('CMS.init start');
+          // Clear any stale reload guard older than 2 minutes on init
+          try {
+            var guard = '__ADMIN_AUTH_RELOADED_PERSIST__';
+            var guardVal = localStorage.getItem(guard);
+            if (guardVal) {
+              var age = Date.now() - parseInt(guardVal || '0', 10);
+              if (age > 120000) { // 2 minutes
+                localStorage.removeItem(guard);
+                log('cleared stale guard');
+              }
+            }
+          } catch(e){}
           CMS.init({ config: window.CMS_CONFIG, load_config_file: false });
           log('CMS.init done');
         } else {


### PR DESCRIPTION
## Issue

Users with stale guards from previous login attempts cannot reload because the 30s window has passed and the guard persists.

## Solution

Added automatic stale guard cleanup on page init:
- Check guard age on every page load
- Remove guard if older than 2 minutes
- Log "cleared stale guard" for visibility

## Combined Fix

This completes the auth flow by combining:
1. ✅ CSP fix (PR #84) - allows unpkg.com connections
2. ✅ Guarded reload (PR #82/83) - forces CMS re-init
3. ✅ **Auto-cleanup (this PR)** - removes stale guards

## Testing

After deployment, try logging in without manually clearing localStorage. Should work seamlessly.