### PR TITLE
Fix: Add 'unsafe-eval' to CSP - THE ACTUAL ROOT CAUSE

### DIFF
--- a/website-integration/ArrowheadSolution/public/_headers
+++ b/website-integration/ArrowheadSolution/public/_headers
@@ -16,4 +16,4 @@
   X-Robots-Tag: noindex, nofollow, noarchive
   Cache-Control: no-store
   X-Frame-Options: SAMEORIGIN
-  Content-Security-Policy: default-src 'self' https://unpkg.com; base-uri 'self'; frame-ancestors 'self'; object-src 'none'; form-action 'self' https://github.com; connect-src 'self' https://api.github.com https://unpkg.com; img-src 'self' data: blob:; style-src 'self' 'unsafe-inline'; font-src 'self' data:; script-src 'self' 'unsafe-inline' https://unpkg.com; frame-src 'self' https://github.com; upgrade-insecure-requests; block-all-mixed-content
+  Content-Security-Policy: default-src 'self' https://unpkg.com; base-uri 'self'; frame-ancestors 'self'; object-src 'none'; form-action 'self' https://github.com; connect-src 'self' https://api.github.com https://unpkg.com; img-src 'self' data: blob:; style-src 'self' 'unsafe-inline'; font-src 'self' data:; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://unpkg.com; frame-src 'self' https://github.com; upgrade-insecure-requests; block-all-mixed-content


### PR DESCRIPTION
## The Real Root Cause (Found in Console)

```
Content Security Policy blocks the use of 'eval' in JavaScript
```

**Decap CMS requires `'unsafe-eval'` to execute dynamic code.**

## The Missing Piece

All previous fixes were necessary but insufficient:
- ✅ Build pipeline (PR #80-81)
- ✅ Redirect rules  
- ✅ CSP unpkg.com (PR #84)
- ✅ Guarded reload (PR #82-83, #85)
- ❌ **CSP was still blocking eval()**

## The Fix

Added `'unsafe-eval'` to `script-src`:

```
script-src 'self' 'unsafe-inline' 'unsafe-eval' https://unpkg.com;
```

## Security Note

This is scoped to `/admin-lite/*` only and is required for Decap CMS to function.

## Testing

After deployment:
1. Login to /admin-lite
2. Console should show NO CSP errors
3. CMS should fully initialize and show collections ✅