### PR TITLE
Fix: Remove CMS_MANUAL_INIT - Enable Auto Token Detection

### DIFF
--- a/website-integration/ArrowheadSolution/client/public/admin-lite/index.html
+++ b/website-integration/ArrowheadSolution/client/public/admin-lite/index.html
@@ -6,8 +6,7 @@
   <title>Decap CMS Admin (Lite)</title>
   <meta name="robots" content="noindex,nofollow,noarchive" />
   <script>
-    // Minimal, isolated sandbox: no custom reloads; just init + diagnostics.
-    window.CMS_MANUAL_INIT = true;
+    // Minimal, isolated sandbox with diagnostics
     window.__ADMIN_LITE__ = { logs: [], gotMessage: false, tokenPersisted: false };
 
     // Inline config with oauth-lite endpoints
@@ -59,6 +58,24 @@
               }
             }
           } catch(e){}
+          
+          // Check if user is already authenticated
+          var existingUser = null;
+          try {
+            var keys = ['decap-cms.user', 'netlify-cms.user', 'decap-cms:user'];
+            for (var i = 0; i < keys.length; i++) {
+              var raw = localStorage.getItem(keys[i]);
+              if (raw) {
+                var parsed = JSON.parse(raw);
+                if (parsed && parsed.token) {
+                  existingUser = parsed;
+                  log('found existing token');
+                  break;
+                }
+              }
+            }
+          } catch(e){ log('token check error: ' + e.message); }
+          
           CMS.init({ config: window.CMS_CONFIG, load_config_file: false });
           log('CMS.init done');
         } else {

--- a/website-integration/ArrowheadSolution/public/admin-lite/index.html
+++ b/website-integration/ArrowheadSolution/public/admin-lite/index.html
@@ -6,8 +6,7 @@
   <title>Decap CMS Admin (Lite)</title>
   <meta name="robots" content="noindex,nofollow,noarchive" />
   <script>
-    // Minimal, isolated sandbox: no custom reloads; just init + diagnostics.
-    window.CMS_MANUAL_INIT = true;
+    // Minimal, isolated sandbox with diagnostics
     window.__ADMIN_LITE__ = { logs: [], gotMessage: false, tokenPersisted: false };
 
     // Inline config with oauth-lite endpoints
@@ -59,6 +58,24 @@
               }
             }
           } catch(e){}
+          
+          // Check if user is already authenticated
+          var existingUser = null;
+          try {
+            var keys = ['decap-cms.user', 'netlify-cms.user', 'decap-cms:user'];
+            for (var i = 0; i < keys.length; i++) {
+              var raw = localStorage.getItem(keys[i]);
+              if (raw) {
+                var parsed = JSON.parse(raw);
+                if (parsed && parsed.token) {
+                  existingUser = parsed;
+                  log('found existing token');
+                  break;
+                }
+              }
+            }
+          } catch(e){ log('token check error: ' + e.message); }
+          
           CMS.init({ config: window.CMS_CONFIG, load_config_file: false });
           log('CMS.init done');
         } else {


### PR DESCRIPTION
## The Final Root Cause

Token is saved ✅, but CMS stays on login screen ❌

Console evidence:
```javascript
window.__ADMIN_LITE__
{gotMessage: true, tokenPersisted: true}

localStorage.getItem('decap-cms.user')
'{"token":"gho_..."}' ✅
```

But also:
```
'window.CMS_MANUAL_INIT' flag set, skipping automatic initialization.
```

## The Issue

`window.CMS_MANUAL_INIT = true` prevents Decap CMS from automatically checking localStorage for existing tokens on page load.

## The Fix

Removed manual init flag. Now:
1. Decap CMS auto-initializes on page load
2. Automatically checks localStorage for tokens
3. Restores authenticated session if token exists

## Testing

After deployment:
1. Token is already in localStorage from previous login
2. Refresh page
3. **CMS should automatically show authenticated UI** ✅