### PR TITLE
Fix: Remove auto-reload that interrupts script loading

### DIFF
--- a/website-integration/ArrowheadSolution/client/public/admin-lite/index.html
+++ b/website-integration/ArrowheadSolution/client/public/admin-lite/index.html
@@ -54,23 +54,8 @@
                 try { localStorage.setItem('netlify-cms-user', JSON.stringify({ token: tok })); } catch(e){}
                 try { localStorage.setItem('decap-cms:user', JSON.stringify({ token: tok })); } catch(e){}
                 try { localStorage.setItem('decap-cms-auth', JSON.stringify({ token: tok, provider: 'github' })); } catch(e){}
-                window.__ADMIN_LITE__.tokenPersisted = true; log('token persisted');
-                // Guarded reload: Decap CMS needs a page refresh to read token from localStorage
-                var guard = '__ADMIN_AUTH_RELOADED_PERSIST__';
-                try {
-                  var guardVal = localStorage.getItem(guard);
-                  var now = Date.now();
-                  // Guard expires after 30 seconds to allow retry if reload failed
-                  var guardAge = guardVal ? now - parseInt(guardVal || '0', 10) : 999999;
-                  if (!guardVal || guardAge > 30000){
-                    localStorage.setItem(guard, now.toString());
-                    log('reloading once');
-                    setTimeout(function(){ location.reload(); }, 150);
-                    return;
-                  } else {
-                    log('guard active, age: ' + Math.floor(guardAge/1000) + 's');
-                  }
-                } catch(e){ log('guard error: ' + e.message); }
+                window.__ADMIN_LITE__.tokenPersisted = true; 
+                log('token saved - close popup and refresh');
               } else {
                 log('no token in message or storage');
               }

--- a/website-integration/ArrowheadSolution/public/admin-lite/index.html
+++ b/website-integration/ArrowheadSolution/public/admin-lite/index.html
@@ -54,23 +54,8 @@
                 try { localStorage.setItem('netlify-cms-user', JSON.stringify({ token: tok })); } catch(e){}
                 try { localStorage.setItem('decap-cms:user', JSON.stringify({ token: tok })); } catch(e){}
                 try { localStorage.setItem('decap-cms-auth', JSON.stringify({ token: tok, provider: 'github' })); } catch(e){}
-                window.__ADMIN_LITE__.tokenPersisted = true; log('token persisted');
-                // Guarded reload: Decap CMS needs a page refresh to read token from localStorage
-                var guard = '__ADMIN_AUTH_RELOADED_PERSIST__';
-                try {
-                  var guardVal = localStorage.getItem(guard);
-                  var now = Date.now();
-                  // Guard expires after 30 seconds to allow retry if reload failed
-                  var guardAge = guardVal ? now - parseInt(guardVal || '0', 10) : 999999;
-                  if (!guardVal || guardAge > 30000){
-                    localStorage.setItem(guard, now.toString());
-                    log('reloading once');
-                    setTimeout(function(){ location.reload(); }, 150);
-                    return;
-                  } else {
-                    log('guard active, age: ' + Math.floor(guardAge/1000) + 's');
-                  }
-                } catch(e){ log('guard error: ' + e.message); }
+                window.__ADMIN_LITE__.tokenPersisted = true; 
+                log('token saved - close popup and refresh');
               } else {
                 log('no token in message or storage');
               }


### PR DESCRIPTION
## Root Cause

After OAuth callback, automatic reload was triggering while page was still loading:

```
GET https://unpkg.com/decap-cms.js
net::ERR_CONNECTION_CLOSED
```

The reload interrupted the script fetch from unpkg.com.

## Why Auto-Reload Is Unnecessary

With `config.yml`, Decap CMS **automatically detects tokens on initialization**. The reload was a workaround for the old inline config approach.

## New Flow (Standard Decap CMS)

1. User clicks "Login with GitHub"
2. OAuth popup opens and exchanges code for token
3. Callback saves token to localStorage
4. Callback closes popup
5. **User manually refreshes main page** (or it auto-refreshes if popup had focus)
6. CMS loads config.yml and detects existing token
7. CMS shows authenticated UI ✅

## Testing

After deployment:
1. Login with GitHub
2. Wait for popup to close
3. Manually refresh the main page (Cmd+R)
4. **CMS should detect token and show collections**